### PR TITLE
Disable dependency libraries

### DIFF
--- a/addons/steam_api/plugin.gd
+++ b/addons/steam_api/plugin.gd
@@ -21,13 +21,17 @@ func _on_disabled(value: bool) -> void:
 	if value:
 		print("disable steam integration")
 		add_autoload_singleton("Steam", "res://addons/steam_api/steam_i.gd")
+		SteamDependencyLibraries.disable()
 	else:
 		print("enable steam integration")
 		add_autoload_singleton("Steam", "res://addons/steam_api/steam.gd")
+		SteamDependencyLibraries.enable()
+
 
 func disable_plugin():
 	remove_autoload_singleton("Steam")
 	remove_control_from_container(CONTAINER_PROJECT_SETTING_TAB_RIGHT, setup)
+	SteamDependencyLibraries.enable()
 	setup.settings.disable = false
 	setup.save_settings()
 	setup.queue_free()

--- a/addons/steam_api/plugin.gd
+++ b/addons/steam_api/plugin.gd
@@ -1,19 +1,21 @@
 tool
 extends EditorPlugin
 
-var setup:Control
+var setup: Control
+
 
 func _enter_tree():
 	setup = load("res://addons/steam_api/setup.tscn").instance()
 	add_control_to_container(CONTAINER_PROJECT_SETTING_TAB_RIGHT, setup)
-	
+
 	setup.connect("disable", self, "_on_disabled")
 
 	var existing_steam_autoload = ProjectSettings.get("autoload/Steam")
 	if not existing_steam_autoload:
 		_on_disabled(setup.settings.disable)
 
-func _on_disabled(value:bool) -> void:
+
+func _on_disabled(value: bool) -> void:
 	remove_autoload_singleton("Steam")
 
 	if value:

--- a/addons/steam_api/plugin.gd
+++ b/addons/steam_api/plugin.gd
@@ -28,4 +28,6 @@ func _on_disabled(value: bool) -> void:
 func disable_plugin():
 	remove_autoload_singleton("Steam")
 	remove_control_from_container(CONTAINER_PROJECT_SETTING_TAB_RIGHT, setup)
+	setup.settings.disable = false
+	setup.save_settings()
 	setup.queue_free()

--- a/addons/steam_api/setup.tscn
+++ b/addons/steam_api/setup.tscn
@@ -62,7 +62,7 @@ margin_right = 510.0
 margin_bottom = 24.0
 rect_min_size = Vector2( 0, 24 )
 size_flags_horizontal = 3
-text = "Disable Steam Integration (all Steam calls will return or yield null)"
+text = "Disable Steam Integration (all Steam calls will return or yield null, and dependency libraries won't be compiled)"
 valign = 1
 
 [node name="input" type="CheckBox" parent="panel/container/disable"]

--- a/addons/steam_api/steam_dependecy_libraries.gd
+++ b/addons/steam_api/steam_dependecy_libraries.gd
@@ -1,0 +1,164 @@
+extends Node
+class_name SteamDependencyLibraries
+
+
+static func get_plugin_base_dir() -> String:
+	return "res://addons/steam_api"
+
+
+static func get_gdnlib_backup_dir() -> String:
+	return "res://addons/steam_api/.gdnlib_backup"
+
+
+static func get_gdns_backup_dir() -> String:
+	return "res://addons/steam_api/.gdns_backup"
+
+
+static func disable() -> void:
+	disable_gdnlib()
+	disable_gdns()
+
+
+static func enable() -> void:
+	enable_gdnlib()
+	enable_gdns()
+
+
+static func disable_gdnlib() -> void:
+	var dir = Directory.new()
+
+	dir.make_dir(get_gdnlib_backup_dir())
+
+	dir.copy(
+		get_plugin_base_dir().plus_file("steam_api.gdnlib"),
+		get_gdnlib_backup_dir().plus_file("steam_api.gdnlib")
+	)
+
+	var gdnlib = load(get_plugin_base_dir().plus_file("steam_api.gdnlib")).config_file
+
+	for entry in gdnlib.get_section_keys("entry"):
+		gdnlib.set_value("entry", entry, "")
+
+	for dependency in gdnlib.get_section_keys("dependencies"):
+		gdnlib.set_value("dependencies", dependency, [])
+
+	gdnlib.save(get_plugin_base_dir().plus_file("steam_api.gdnlib"))
+
+
+static func enable_gdnlib() -> void:
+	var dir = Directory.new()
+
+	if not dir.dir_exists(get_gdnlib_backup_dir()):
+		return
+
+	dir.copy(
+		get_gdnlib_backup_dir().plus_file("steam_api.gdnlib"),
+		get_plugin_base_dir().plus_file("steam_api.gdnlib")
+	)
+
+	if dir.open(get_gdnlib_backup_dir()) == OK:
+		dir.list_dir_begin()
+
+		var file_name = dir.get_next()
+
+		while file_name != "":
+			if not dir.current_is_dir():
+				dir.remove(get_gdnlib_backup_dir().plus_file(file_name))
+
+			file_name = dir.get_next()
+
+		dir.list_dir_end()
+	else:
+		print("An error occurred when trying to access the path.")
+
+	dir.remove(get_gdnlib_backup_dir())
+
+
+static func disable_gdns() -> void:
+	var dir = Directory.new()
+
+	dir.make_dir(get_gdns_backup_dir())
+
+	if dir.open(get_plugin_base_dir()) == OK:
+		dir.list_dir_begin()
+
+		var file_name = dir.get_next()
+
+		while file_name != "":
+			if not dir.current_is_dir():
+				if file_name.get_extension() == "gdns":
+					var file := get_plugin_base_dir().plus_file(file_name)
+					var gdns_backup_file := get_gdns_backup_dir().plus_file(file_name)
+
+					dir.copy(file, gdns_backup_file)
+
+					var lines := []
+					var output_string := ""
+
+					var f = File.new()
+
+					f.open(file, File.READ)
+					while not f.eof_reached():
+						lines.append(f.get_line())
+					f.close()
+
+					var line_index := 0
+					for _i in lines.size():
+						if line_index >= lines.size():
+							break
+
+						var line = lines[line_index]
+
+						if "gd_resource" in line:
+							line = line.replace("load_steps=2", "load_steps=1")
+
+						if "ext_resource" in line or "library" in line:
+							line_index += 1
+							if lines[line_index - 2] == "":
+								line_index += 1
+							continue
+
+						output_string += line
+
+						if line_index != lines.size() - 1:
+							output_string += "\n"
+
+						line_index += 1
+
+					f.open(file, File.WRITE)
+					f.store_string(output_string)
+					f.close()
+
+			file_name = dir.get_next()
+
+		dir.list_dir_end()
+	else:
+		print("An error occurred when trying to access the path.")
+
+
+static func enable_gdns() -> void:
+	var dir = Directory.new()
+
+	if not dir.dir_exists(get_gdns_backup_dir()):
+		return
+
+	if dir.open(get_gdns_backup_dir()) == OK:
+		dir.list_dir_begin()
+
+		var file_name = dir.get_next()
+
+		while file_name != "":
+			if not dir.current_is_dir():
+				var file := get_plugin_base_dir().plus_file(file_name)
+				var gdns_backup_file := get_gdns_backup_dir().plus_file(file_name)
+
+				dir.copy(gdns_backup_file, file)
+				dir.remove(gdns_backup_file)
+
+			file_name = dir.get_next()
+
+		dir.list_dir_end()
+	else:
+		print("An error occurred when trying to access the path.")
+
+	dir.remove(get_gdns_backup_dir())

--- a/app/project.godot
+++ b/app/project.godot
@@ -24,6 +24,11 @@ _global_script_classes=[ {
 "language": "NativeScript",
 "path": "res://addons/steam_api/steam_callback.gdns"
 }, {
+"base": "Node",
+"class": "SteamDependencyLibraries",
+"language": "GDScript",
+"path": "res://addons/steam_api/steam_dependecy_libraries.gd"
+}, {
 "base": "",
 "class": "SteamFriends",
 "language": "NativeScript",
@@ -88,6 +93,7 @@ _global_script_class_icons={
 "SteamAPI": "",
 "SteamApps": "",
 "SteamCallback": "",
+"SteamDependencyLibraries": "",
 "SteamFriends": "",
 "SteamI": "",
 "SteamId": "",


### PR DESCRIPTION
I've created a new `SteamDependencyLibraries` class to enable/disable the dependency libraries, so they won't be compiled when "Steam integration" is disabled.

Basically, what it does, is when the user clicks on the "Disable Steam Integration" checkbox, it creates backups of all the `.gdns` and `.gdnlib`, and then removes stuff from the originals so the dependency libraries won't be compiled.
When the user enables the Steam Integration, all those files are reverted back to its originals.

As a little bonus, I've fixed an issue. When the "Steam integration" is disabled and the user disables the plugin, the disabled state stays and when the user enables back the plugin it still disabled. I made it so it is enabled when the plugin is enabled.